### PR TITLE
Updating check_if_programs_exists () to accommodate samtools doc change

### DIFF
--- a/filter_bam_file_for_popscle_dsc_pileup.sh
+++ b/filter_bam_file_for_popscle_dsc_pileup.sh
@@ -47,7 +47,7 @@ check_if_programs_exists () {
     fi
 
     # Check if samtools 1.10 or higher is installed (needs to have "-D STR:FILE" option).
-    if ! samtools view --help 2>&1 | grep -q -- '-D STR:FILE' ; then
+    if ! samtools --version 2>&1 | awk '$0 ~ /^samtools/{if($2 < 1.10) exit 1}' ; then
         printf 'Error: The version of "samtools" (%s) should be 1.10 or higher (%s found).\n' \
             "$(type samtools)" \
             "$(samtools --version | head -n 1)" \


### PR DESCRIPTION
Hi Aerts lab,

Thank you for sharing these tools that make processing data for `demuxlet` much more enjoyable. I noticed that [the help page for `samtools view`](https://www.htslib.org/doc/samtools-view.html) has been updated, and as a result,  running `check_if_programs_exists ()` with samtools v1.14 will return an error because the description of `-D` flag has changed.

### Purposed changes

Please find submitted an alternative that parses `samtools --version` with `awk` and returns 0 if the parsed version is below 1.10.

### Environment

The revision is tested on a Linux machine with the following software loaded:
```
1) perl/intel/5.32.0 
2) htslib/intel/1.14
3) samtools/intel/1.14
4) intel/19.1.2 # Intel compilers
5) bedtools/intel/2.29.2
```

### Testing

`check_if_programs_exists ()` returns no error in this environment while shows the expected error message if [the minimum version number](https://github.com/chenyenchung/popscle_helper_tools/blob/d86b133a6cef6e904ce77d06e2dfbbba8afc22c7/filter_bam_file_for_popscle_dsc_pileup.sh#L50) (in `awk '$0 ~ /^samtools/{if($2 < 1.10) exit 1}'`) is changed to 1.15 instead of 1.10.

Please let me know if you have any questions. Thank you!